### PR TITLE
Enable jekyll feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,4 +56,4 @@ gems:
   - jekyll-redirect-from
   - jekyll-sitemap
 
-  # - jekyll-feed
+  - jekyll-feed

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,9 +8,5 @@
 
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
-{% comment %}
-  TODO: enable when https://github.com/jekyll/jekyll-feed/commit/3321d8bae50101a819fac942888269d333c8027a is released
   {% feed_meta %}
-{% endcomment %}
 </head>


### PR DESCRIPTION
Enable when https://github.com/jekyll/jekyll-feed/commit/3321d8bae50101a819fac942888269d333c8027a is released.

Check by:

```
git clone https://github.com/jekyll/jekyll-feed # locally
git tag --contains 3321d8bae50101a819fac942888269d333c8027a
# install/update jekyll-feed at least to that version
```
